### PR TITLE
feature: Allow generate_markdown.py accept specified inputfile.

### DIFF
--- a/generate_markdown.py
+++ b/generate_markdown.py
@@ -27,7 +27,19 @@ def make_table(data, *, predicate=is_owned_by_aura):
 
 
 if __name__ == '__main__':
-    data = json.load(sys.stdin)
+    try:
+        input_file = open(sys.argv[1], 'r')
+    except IndexError:
+        input_file = sys.stdin
+    with input_file as f:
+        json_string = f.read()
+
+    try:
+        data = json.loads(json_string)
+    except json.decoder.JSONDecodeError as e:
+        print('\n' + input_string, file=sys.stderr, end='\n\n)
+        raise e
+
     doc_body = textwrap.dedent('''\
     # Helikopteroversikt
 

--- a/generate_markdown.py
+++ b/generate_markdown.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3 
 
+import argparse
 import json
 import sys
 import textwrap
@@ -27,19 +28,29 @@ def make_table(data, *, predicate=is_owned_by_aura):
 
 
 if __name__ == '__main__':
-    try:
-        input_file = open(sys.argv[1], 'r')
-    except IndexError:
-        input_file = sys.stdin
-    with input_file as f:
-        json_string = f.read()
+    # Set up CLI
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        'input_file',
+        nargs='?',
+        type=argparse.FileType('r'),
+        default=sys.stdin,
+        help='JSON input file. Defaults to stdin when not defined.',
+    )
+    args = parser.parse_args()
 
+    # Parse input
     try:
-        data = json.loads(json_string)
-    except json.decoder.JSONDecodeError as e:
-        print('\n' + input_string, file=sys.stderr, end='\n\n)
-        raise e
+        data = json.load(args.input_file)
+    except json.decoder.JSONDecodeError:
+        error_source = '<stdin>' if args.input_file is sys.stdin else args.input_file
+        print(
+            f"\nInvalid JSON in '{error_source}' - ensure the file/stdin contains valid JSON.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
 
+    # Tabulate and write output
     doc_body = textwrap.dedent('''\
     # Helikopteroversikt
 


### PR DESCRIPTION
Now `generate_markdown.py` accepts both `<echo/cat json> | generate_markdown.py` and `generate_markdown.py <filepath>` invocations.